### PR TITLE
Patch .gitattributes related with jpg file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 * text eol=lf
 
-*.jpg binary
 *.png binary
 *.gif binary
 *.ico binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 * text eol=lf
 
+*.jpg binary
 *.png binary
 *.gif binary
 *.ico binary


### PR DESCRIPTION
Jpg files are binary, and there are jpeg files in tests and examples folders. This fix a problem I have when git think that images are modified, but they are not.

(I prefer do my contributions via PR)