### PR TITLE
Add exception for invalid or corrupted image files

### DIFF
--- a/src/PHPThumb/GD.php
+++ b/src/PHPThumb/GD.php
@@ -90,6 +90,12 @@ class GD extends PHPThumb
 			'WEBP'		=> imagecreatefromwebp		($this->file_name),
 		};
 
+		if ($this->old_image === false)
+		{
+			// Could not decode image
+			throw new Exception('The image file is invalid, corrupted, or the required ' . $this->format . ' codec is not available in the GD library.');
+		}
+		
 		$this->current_dimensions = [
 			'width'		=> imagesx($this->old_image),
 			'height'	=> imagesy($this->old_image)


### PR DESCRIPTION
To prevent a fatal error when a GD function like imagesx() receives a false value due to a missing or unsupported image codec, it validates the return value of image creation functions before using them. Functions such as imagecreatefromjpeg(), imagecreatefrompng(), and imagecreatefromwebp() can return false if the image file is invalid, corrupted, or if the required codec (e.g., AVIF, WEBP) is not available in the GD library.

- fixes #12